### PR TITLE
fix (deps): use prettier-with-tabs package

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,6 @@
     "@types/mocha": "^2.2.32"
   },
   "dependencies": {
-    "prettier": "0.22.0"
+    "prettier-with-tabs": "0.22.0"
   }
 }


### PR DESCRIPTION
it was requiring `prettier` instead of `prettier-with-tabs`